### PR TITLE
fixes #3: Do not depend on existence of 'to' and 'from'

### DIFF
--- a/src/changelog.html
+++ b/src/changelog.html
@@ -44,6 +44,10 @@
     MUC Real-Time Block List Plugin Changelog
 </h1>
 
+<p><b>1.0.1</b> -- (TBD)</p>
+<ul>
+    <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/3">Issue #3</a>: NullPointerException while processing stanza without 'to' or 'from' address</li>
+</ul>
 
 <p><b>1.0.0</b> -- February 23, 2023</p>
 <ul>

--- a/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/PubSubHandler.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/PubSubHandler.java
@@ -84,11 +84,11 @@ public class PubSubHandler implements PacketInterceptor
             return;
         }
 
-        if (!stanza.getFrom().equals(service)) {
+        if (!service.equals(stanza.getFrom())) {
             return;
         }
 
-        if (!stanza.getTo().equals(selfAddress)) {
+        if (!selfAddress.equals(stanza.getTo())) {
             return;
         }
 

--- a/src/plugin.xml
+++ b/src/plugin.xml
@@ -6,7 +6,7 @@
     <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>2023-02-23</date>
+    <date>2023-02-24</date>
     <minServerVersion>4.7.0</minServerVersion>
 
     <adminconsole>


### PR DESCRIPTION
Stanzas typically have a 'to' and 'from' attribute, which holds JIDs (used for addressing). For some stanzas, these attributes are absent.

The plugin's PubSubHandler incorrectly assumed that both attributes are always present. That is fixed by this commit.