### PR TITLE
fixes #8: Show reason in admin console

### DIFF
--- a/src/changelog.html
+++ b/src/changelog.html
@@ -46,6 +46,7 @@
 
 <p><b>1.0.1</b> -- (TBD)</p>
 <ul>
+    <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/8">Issue #8</a>: On admin console, show reason for item being on block list (if possible).</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/6">Issue #6</a>: Have a (liberal) maximum to the size of the blocklist, to avoid abuse</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/5">Issue #5</a>: Entries should not disappear over time</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/3">Issue #3</a>: NullPointerException while processing stanza without 'to' or 'from' address</li>

--- a/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockList.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockList.java
@@ -104,11 +104,11 @@ public class BlockList
         }
     }
 
-    public void addAll(final Collection<String> hashes) {
+    public void addAll(final Map<String, String> hashes) {
         final Map<String, String> toAdd = new HashMap<>();
-        for (final String hash : hashes) {
-            if (hash != null && hash.matches("^[a-fA-F0-9]{64}$")) {
-                toAdd.put(hash, "");
+        for (final Map.Entry<String, String> hash : hashes.entrySet()) {
+            if (hash.getKey() != null && hash.getKey().matches("^[a-fA-F0-9]{64}$")) {
+                toAdd.put(hash.getKey(), hash.getValue());
             }
         }
 
@@ -135,9 +135,9 @@ public class BlockList
         }
     }
 
-    public void add(final String hash)
+    public void add(final String hash, final String reason)
     {
-        addAll(Collections.singletonList(hash));
+        addAll(Collections.singletonMap(hash, reason));
     }
 
     public void removeAll(final Collection<String> hashes) {
@@ -172,11 +172,11 @@ public class BlockList
         removeAll(Collections.singletonList(hash));
     }
 
-    public Set<String> getAll() {
+    public Map<String, String> getAll() {
         final Lock lock = blockedHashes.getLock(CACHE_MUTEX);
         try {
             lock.lock();
-            return new HashSet<>(blockedHashes.keySet());
+            return new HashMap<>(blockedHashes);
         } finally {
             lock.unlock();
         }

--- a/src/main/web/mucrtbl.jsp
+++ b/src/main/web/mucrtbl.jsp
@@ -84,7 +84,7 @@
     pageContext.setAttribute( "serviceNode", MucRealTimeBlockListPlugin.BLOCKLIST_SERVICE_NODE.getValue() );
     pageContext.setAttribute( "stanzaBlockerEnabled", !MucRealTimeBlockListPlugin.BLOCKLIST_STANZABLOCKER_DISABLED.getValue() );
     pageContext.setAttribute( "occupantRemoverEnabled", !MucRealTimeBlockListPlugin.BLOCKLIST_OCCUPANTREMOVER_DISABLED.getValue() );
-    pageContext.setAttribute( "hashes", plugin.getBlockList() == null ? Collections.emptySet() : plugin.getBlockList().getAll() );
+    pageContext.setAttribute( "hashes", plugin.getBlockList() == null ? Collections.emptyMap() : plugin.getBlockList().getAll() );
 %>
 <html>
 <head>
@@ -190,8 +190,8 @@
     <c:if test="${hashes.size() < 50 && hashes.size() > 0}">
         <p><fmt:message key="mucrtbl.page.content.hashes"/></p>
         <ul style="margin: 1em; list-style: initial">
-            <c:forEach items="${hashes}" var="hash">
-                <li style="list-style: initial"><code></code><c:out value="${hash}"/></li>
+            <c:forEach items="${hashes}" var="entry">
+                <li style="list-style: initial"><code><c:out value="${entry.key}"/></code> <c:out value="${entry.value}"/></li>
             </c:forEach>
         </ul>
     </c:if>

--- a/src/test/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockListEventListenerTest.java
+++ b/src/test/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockListEventListenerTest.java
@@ -27,6 +27,8 @@ import org.xmpp.packet.JID;
 import org.mockito.junit.*;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.*;
@@ -59,7 +61,7 @@ public class BlockListEventListenerTest
         final String needle = "bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d"; // hash of: unit-test@xmpp.org
 
         // Execute system under test
-        bl.add(needle);
+        bl.add(needle, "");
 
         // Verify results
         final ArgumentCaptor<Set<String>> argumentCaptor = ArgumentCaptor.forClass(Set.class);
@@ -81,9 +83,12 @@ public class BlockListEventListenerTest
         bl.register(eventListener);
         final String needleA = "bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d"; // hash of: unit-test@xmpp.org
         final String needleB = "8f96e8e5f1f082c2d56d15db2a9f4888040a621c02bdd0b4375d1f51bc96991a"; // hash of: unit-test-too@example.org
+        final Map<String, String> input = new HashMap<>();
+        input.put(needleA, "test");
+        input.put(needleB, "unit-test");
 
         // Execute system under test
-        bl.addAll(Arrays.asList(needleA, needleB));
+        bl.addAll(input);
 
         // Verify results
         final ArgumentCaptor<Set<String>> argumentCaptor = ArgumentCaptor.forClass(Set.class);
@@ -107,7 +112,7 @@ public class BlockListEventListenerTest
         final String needle = "bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d"; // hash of: unit-test@xmpp.org
 
         // Execute system under test
-        bl.add(needle);
+        bl.add(needle, "unit-test");
         bl.remove(needle);
 
         // Verify results
@@ -131,9 +136,12 @@ public class BlockListEventListenerTest
         bl.register(eventListener);
         final String needleA = "bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d"; // hash of: unit-test@xmpp.org
         final String needleB = "8f96e8e5f1f082c2d56d15db2a9f4888040a621c02bdd0b4375d1f51bc96991a"; // hash of: unit-test-too@example.org
+        final Map<String, String> input = new HashMap<>();
+        input.put(needleA, "test");
+        input.put(needleB, "unit-test");
 
         // Execute system under test
-        bl.addAll(Arrays.asList(needleA, needleB));
+        bl.addAll(input);
         bl.removeAll(Arrays.asList(needleA, needleB));
 
         // Verify results
@@ -159,9 +167,9 @@ public class BlockListEventListenerTest
         final String needle = "bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d"; // hash of: unit-test@xmpp.org
 
         // Execute system under test
-        bl.add(needle);
+        bl.add(needle, "unit-test");
         Mockito.reset(eventListener);
-        bl.add(needle);
+        bl.add(needle, "test");
 
         // Verify results
         Mockito.verify(eventListener, Mockito.never()).added(Mockito.anySet());
@@ -204,9 +212,9 @@ public class BlockListEventListenerTest
         final String needleB = "8f96e8e5f1f082c2d56d15db2a9f4888040a621c02bdd0b4375d1f51bc96991a"; // hash of: unit-test-too@example.org
 
         // Execute system under test
-        bl.add(needleA);
+        bl.add(needleA, "unit-test");
         Mockito.reset(eventListener);
-        bl.add(needleB);
+        bl.add(needleB,"test");
 
         // Verify results
         final ArgumentCaptor<Set<String>> argumentCaptor = ArgumentCaptor.forClass(Set.class);
@@ -232,7 +240,7 @@ public class BlockListEventListenerTest
         final String needleB = "8f96e8e5f1f082c2d56d15db2a9f4888040a621c02bdd0b4375d1f51bc96991a"; // hash of: unit-test-too@example.org
 
         // Execute system under test
-        bl.add(needleB);
+        bl.add(needleB, "unit-test");
         bl.removeAll(Arrays.asList(needleA, needleB));
 
         // Verify results
@@ -260,7 +268,7 @@ public class BlockListEventListenerTest
         final String needle = "bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d"; // hash of: unit-test@xmpp.org
 
         // Execute system under test
-        blB.add(needle);
+        blB.add(needle, "unit-test");
 
         // Verify results
         Mockito.verifyNoMoreInteractions(eventListener);

--- a/src/test/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockListTest.java
+++ b/src/test/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockListTest.java
@@ -62,7 +62,7 @@ public class BlockListTest
     {
         // Setup test fixture.
         final BlockList bl = new BlockList();
-        bl.add("60eb02d00ee3bdd0c46d9c6a360037882a9137902f3533a78fa73aae2ec9dbe2"); // unit-test-not-on-list@example.com
+        bl.add("60eb02d00ee3bdd0c46d9c6a360037882a9137902f3533a78fa73aae2ec9dbe2", "unit-test"); // unit-test-not-on-list@example.com
         final JID target = new JID("unit-test@xmpp.org/resource");
 
         // Execute system under test
@@ -80,7 +80,7 @@ public class BlockListTest
     {
         // Setup test fixture.
         final BlockList bl = new BlockList();
-        bl.add("bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d"); // unit-test@xmpp.org
+        bl.add("bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d", "unit-test"); // unit-test@xmpp.org
         final JID target = new JID("unit-test@xmpp.org");
 
         // Execute system under test
@@ -98,7 +98,7 @@ public class BlockListTest
     {
         // Setup test fixture.
         final BlockList bl = new BlockList();
-        bl.add("bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d"); // unit-test@xmpp.org
+        bl.add("bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d", "unit-test"); // unit-test@xmpp.org
         final JID target = new JID("unit-test@xmpp.org/resource");
 
         // Execute system under test
@@ -116,7 +116,7 @@ public class BlockListTest
     {
         // Setup test fixture.
         final BlockList bl = new BlockList();
-        bl.add("bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d"); // unit-test@xmpp.org
+        bl.add("bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d", "unit-test"); // unit-test@xmpp.org
         bl.remove("bd42ad42bf32b98a903f3c3eb5206d9bb318df597db9df7167ed6659db4b3f7d");
         final JID target = new JID("unit-test@xmpp.org/resource");
 


### PR DESCRIPTION
Block list pub/sub events optionally contain a reporting element. If that's available, Openfire should display its content on the admin console.