### PR TITLE
fixes #11: Provide default configuration

### DIFF
--- a/src/changelog.html
+++ b/src/changelog.html
@@ -46,6 +46,7 @@
 
 <p><b>1.0.1</b> -- (TBD)</p>
 <ul>
+    <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/11">Issue #11</a>: Provide a default pub/sub service and node.</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/8">Issue #8</a>: On admin console, show reason for item being on block list (if possible).</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/6">Issue #6</a>: Have a (liberal) maximum to the size of the blocklist, to avoid abuse</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/5">Issue #5</a>: Entries should not disappear over time</li>

--- a/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/MucRealTimeBlockListPlugin.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/MucRealTimeBlockListPlugin.java
@@ -48,6 +48,7 @@ public class MucRealTimeBlockListPlugin implements Plugin
     public static final SystemProperty<JID> BLOCKLIST_SERVICE_JID = SystemProperty.Builder.ofType(JID.class)
         .setKey("plugin.mucrtbl.blocklist.service")
         .setPlugin("MUC Real-Time Block List")
+        .setDefaultValue(new JID("xmppbl.org"))
         .setDynamic(true)
         .addListener(o -> reInit())
         .build();
@@ -55,6 +56,7 @@ public class MucRealTimeBlockListPlugin implements Plugin
     public static final SystemProperty<String> BLOCKLIST_SERVICE_NODE = SystemProperty.Builder.ofType(String.class)
         .setKey("plugin.mucrtbl.blocklist.node")
         .setPlugin("MUC Real-Time Block List")
+        .setDefaultValue("muc_bans_sha256")
         .setDynamic(true)
         .addListener(o -> reInit())
         .build();

--- a/src/readme.html
+++ b/src/readme.html
@@ -97,6 +97,11 @@
     to configure the plugin.
 </p>
 
+<p>
+    The default configuration of the plugin will cause it to use the block list that is advertised on the
+    <a href="https://xmppbl.org/">xmppbl.org</a> domain.
+</p>
+
 <h2>Attribution</h2>
 <p>
     <a href="https://www.flaticon.com/free-icons/block" title="block icons">Block icons created by Those Icons - Flaticon</a>


### PR DESCRIPTION
By providing a default block list, administrators do not need to search for an applicable service.