### PR TITLE
fixes #10: Add support for domains to be on the block list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>mucrtbl</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>MUC Real-Time Block List</name>
     <description>A plugin that subscribes to a real-time block list for MUC rooms, using pub/sub.</description>

--- a/src/changelog.html
+++ b/src/changelog.html
@@ -44,9 +44,10 @@
     MUC Real-Time Block List Plugin Changelog
 </h1>
 
-<p><b>1.0.1</b> -- (TBD)</p>
+<p><b>1.1.0</b> -- (TBD)</p>
 <ul>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/11">Issue #11</a>: Provide a default pub/sub service and node.</li>
+    <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/10">Issue #10</a>: Allow for block list entries to be an entire domain, rather than a single user.</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/8">Issue #8</a>: On admin console, show reason for item being on block list (if possible).</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/6">Issue #6</a>: Have a (liberal) maximum to the size of the blocklist, to avoid abuse</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/5">Issue #5</a>: Entries should not disappear over time</li>

--- a/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockList.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockList.java
@@ -15,7 +15,6 @@
  */
 package org.igniterealtime.openfire.plugin.mucrtbl;
 
-import org.jivesoftware.util.JiveGlobals;
 import org.jivesoftware.util.StringUtils;
 import org.jivesoftware.util.cache.Cache;
 import org.jivesoftware.util.cache.CacheFactory;
@@ -24,6 +23,8 @@ import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
 
 public class BlockList
@@ -33,7 +34,7 @@ public class BlockList
     private static final String CACHE_MUTEX = "mutex-for-blocklist-cache";
 
     /**
-     * Collection of hashes of bare JIDs that are blocked.
+     * Collection of hashes of bare JIDs or domain-part-only JIDs that are blocked.
      */
     private final Cache<String, String> blockedHashes;
 
@@ -55,12 +56,13 @@ public class BlockList
      * @return true if the JID is on the block list, otherwise false.
      */
     public boolean contains(final JID jid) {
-        final String hash = StringUtils.hash(jid.toBareJID(), "SHA-256");
+        final String bareJidHash = StringUtils.hash(jid.toBareJID(), "SHA-256");
+        final String domainHash = StringUtils.hash(jid.getDomain(), "SHA-256");
 
         final Lock lock = blockedHashes.getLock(CACHE_MUTEX);
         try {
             lock.lock();
-            return blockedHashes.containsKey(hash);
+            return blockedHashes.containsKey(bareJidHash) || blockedHashes.containsKey(domainHash);
         } finally {
             lock.unlock();
         }
@@ -69,8 +71,8 @@ public class BlockList
     /**
      * From a collection of JIDs, return only those that are on the block list.
      *
-     * This method will verify if the SHA-256 hash of the bare JID exists on the block list, returning the original JID
-     * in the result when that is the case.
+     * This method will verify if the SHA-256 hash of the bare JID or the domain-part of the JID exists on the block
+     * list, returning the original JID in the result when that is the case.
      *
      * @param jids The JIDs for which to check the block list
      * @return A collection with JIDs that are on the block list. Possibly empty, never null.
@@ -78,10 +80,12 @@ public class BlockList
     public Set<JID> filterBlocked(final Collection<JID> jids) {
         // First calculate all hashes, then check the cache. This is aimed to reduce the amount and total duration of
         // cache locks that are held.
-        final Map<String, JID> hashes = new HashMap<>();
+        final ConcurrentMap<String, Set<JID>> hashes = new ConcurrentHashMap<>();
         for (final JID jid : jids) {
-            final String hash = StringUtils.hash(jid.toBareJID(), "SHA-256");
-            hashes.put(hash, jid);
+            final String bareJidHash = StringUtils.hash(jid.toBareJID(), "SHA-256");
+            final String domainHash = StringUtils.hash(jid.getDomain(), "SHA-256");
+            hashes.computeIfAbsent(bareJidHash, k -> new HashSet<>()).add(jid);
+            hashes.computeIfAbsent(domainHash, k -> new HashSet<>()).add(jid);
         }
 
         final Set<JID> result = new HashSet<>();
@@ -93,9 +97,9 @@ public class BlockList
         final Lock lock = blockedHashes.getLock(CACHE_MUTEX);
         try {
             lock.lock();
-            for (final Map.Entry<String, JID> entry : hashes.entrySet()) {
+            for (final Map.Entry<String, Set<JID>> entry : hashes.entrySet()) {
                 if (blockedHashes.containsKey(entry.getKey())) {
-                    result.add(entry.getValue());
+                    result.addAll(entry.getValue());
                 }
             }
             return result;
@@ -104,6 +108,15 @@ public class BlockList
         }
     }
 
+    /**
+     * Adds a collection of hashes of a JIDs to the block list, with an optional human-readable reason for why the entry
+     * was added to the block list.
+     *
+     * The hashes that is provided is expected to be of a normalized JID that is either a bare, or consist of only a
+     * domain-part.
+     *
+     * @param hashes A map of hashes to be added, mapped to optional human-readible reasons for the hashes to be added.
+     */
     public void addAll(final Map<String, String> hashes) {
         final Map<String, String> toAdd = new HashMap<>();
         for (final Map.Entry<String, String> hash : hashes.entrySet()) {
@@ -135,6 +148,16 @@ public class BlockList
         }
     }
 
+    /**
+     * Adds the hash of a JID to the block list, with an optional human-readable reason for why the entry was added to
+     * the block list.
+     *
+     * The hash that is provided is expected to be of a normalized JID that is either a bare, or consist of only a
+     * domain-part.
+     *
+     * @param hash A hash
+     * @param reason An optional reason for the hash to exist on the block list.
+     */
     public void add(final String hash, final String reason)
     {
         addAll(Collections.singletonMap(hash, reason));
@@ -172,6 +195,13 @@ public class BlockList
         removeAll(Collections.singletonList(hash));
     }
 
+    /**
+     * Gets a defensive copy of all hashes on the block list, mapped to an optional human reason for the entry to exist
+     * on the block list.
+     *
+     * The hashes are expected to be those of normalized JIDs that are either bare, or consist of a domain-part only.
+     * When comparing, JIDs should always be normalized.
+     */
     public Map<String, String> getAll() {
         final Lock lock = blockedHashes.getLock(CACHE_MUTEX);
         try {

--- a/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockList.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockList.java
@@ -112,7 +112,7 @@ public class BlockList
      * Adds a collection of hashes of a JIDs to the block list, with an optional human-readable reason for why the entry
      * was added to the block list.
      *
-     * The hashes that is provided is expected to be of a normalized JID that is either a bare, or consist of only a
+     * Each of the hashes that is provided is expected to be of a normalized JID that is either a bare, or consist of only a
      * domain-part.
      *
      * @param hashes A map of hashes to be added, mapped to optional human-readible reasons for the hashes to be added.

--- a/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockListEventListener.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/BlockListEventListener.java
@@ -20,6 +20,11 @@ import java.util.Set;
 /**
  * A listener of events that relate to adding or removing entries on a block list.
  *
+ * Note that the hashes that are provided as the arguments to the event listeners are expected to be of JIDs that are
+ * either bare, or consist of only a domain-part. Implementations should check both the bare JID (e.g. user@example.com)
+ * and the domain (e.g. example.com) against the list, to support domain-wide blocks of rogue servers. JIDs should
+ * always be normalized before comparison or hashing.
+ *
  * @author Guus der Kinderen, guus@goodbytes.nl
  */
 public interface BlockListEventListener


### PR DESCRIPTION
Prior to this change, block list entries were expected to be bare JIDs. To support domain-wide blocks of rogue servers, entries can also be JIDs that consist of a domain-part only.

Bumped the version number, as this is quite a significant change.