### PR TITLE
fixes #14: Add periodic refresh task

### DIFF
--- a/src/changelog.html
+++ b/src/changelog.html
@@ -46,6 +46,7 @@
 
 <p><b>1.1.0</b> -- (TBD)</p>
 <ul>
+    <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/14">Issue #14</a>: Added a periodic refresh task.</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/11">Issue #11</a>: Provide a default pub/sub service and node.</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/10">Issue #10</a>: Allow for block list entries to be an entire domain, rather than a single user.</li>
     <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/8">Issue #8</a>: On admin console, show reason for item being on block list (if possible).</li>

--- a/src/main/i18n/mucrealtimeblocklist_i18n.properties
+++ b/src/main/i18n/mucrealtimeblocklist_i18n.properties
@@ -2,3 +2,5 @@ system_property.plugin.mucrtbl.blocklist.service=Pub/Sub service name that conta
 system_property.plugin.mucrtbl.blocklist.node=Name of the node that contains the MUC RealTime Block List hashes.
 system_property.plugin.mucrtbl.blocklist.stanzablocker.disabled=Controls if entities on the block list can send stanzas to MUC services.
 system_property.plugin.mucrtbl.blocklist.occupantremover.disabled=Controls if Openfire iterates over all rooms to remove an entity that is newly added to the block list.
+system_property.plugin.mucrtbl.blocklist.refreshtask.disabled=Controls if Openfire will periodically try to refresh the content of the block list by polling the Pub/Sub service.
+system_property.plugin.mucrtbl.blocklist.refreshtask.interval=The amount of time between attempts to refresh the block list.


### PR DESCRIPTION
This adds a periodic task (configurable, but enabled by default and runs once each 6 hours) that will re-retrieve all entities from the configured pub/sub service. This intends to clean up if any unforeseen mishaps cause the block list to be incomplete.