### PR TITLE
Fix compatibility issue with Openfire 4.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.7.0</version>
+        <version>4.8.1</version>
     </parent>
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>mucrtbl</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <name>MUC Real-Time Block List</name>
     <description>A plugin that subscribes to a real-time block list for MUC rooms, using pub/sub.</description>

--- a/src/changelog.html
+++ b/src/changelog.html
@@ -44,9 +44,11 @@
     MUC Real-Time Block List Plugin Changelog
 </h1>
 
-<p><b>1.1.1</b> -- (tbd)</p>
+<p><b>1.2.0</b> -- (tbd)</p>
 <ul>
+    <li>Now requires Openfire 4.8.1 or later.</li>
     <li>Added Portuguese translation (as provided by Transifex's MeGaBeSuNTa).</li>
+    <li><a href="https://github.com/igniterealtime/openfire-mucrtbl-plugin/issues/23">Issue #23</a>: Fix compatibility with Openfire 4.9.0.</li>
 </ul>
 
 <p><b>1.1.0</b> -- March 18, 2023</p>

--- a/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/MucRealTimeBlockListPlugin.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/MucRealTimeBlockListPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,7 +144,7 @@ public class MucRealTimeBlockListPlugin implements Plugin
 
         if (!BLOCKLIST_REFRESHTASK_DISABLED.getValue()) {
             refreshTask = new RefreshTask();
-            TaskEngine.getInstance().schedule(refreshTask, BLOCKLIST_REFRESHTASK_INTERVAL.getValue().toMillis(), BLOCKLIST_REFRESHTASK_INTERVAL.getValue().toMillis());
+            TaskEngine.getInstance().schedule(refreshTask, BLOCKLIST_REFRESHTASK_INTERVAL.getValue(), BLOCKLIST_REFRESHTASK_INTERVAL.getValue());
         }
         Log.debug("Started.");
     }

--- a/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/OccupantRemover.java
+++ b/src/main/java/org/igniterealtime/openfire/plugin/mucrtbl/OccupantRemover.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2023-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,7 @@ import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
 
 import javax.annotation.Nonnull;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.locks.Lock;
 import java.util.stream.Collectors;
 
@@ -62,7 +60,10 @@ public class OccupantRemover implements BlockListEventListener
         for (MultiUserChatService service : multiUserChatServices)
         {
             // Use the JIDs of all occupants of MUC rooms of the service
-            final Map<JID, Set<OccupantManager.Occupant>> occupantsByJID = service.getOccupantManager().getNodesByOccupant().keySet().stream()
+            final Collection<OccupantManager.Occupant> allOccupants = new HashSet<>();
+            service.getOccupantManager().getLocalOccupantsByNode().values().forEach(allOccupants::addAll);
+            allOccupants.addAll(service.getOccupantManager().getFederatedOccupants());
+            final Map<JID, Set<OccupantManager.Occupant>> occupantsByJID = allOccupants.stream()
                 .collect(Collectors.groupingBy(OccupantManager.Occupant::getRealJID, Collectors.toSet()));
 
             // Determine which of these JIDs are on the blocklist (if any). Note that this operates on the entire block

--- a/src/plugin.xml
+++ b/src/plugin.xml
@@ -6,8 +6,8 @@
     <description>${project.description}</description>
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
-    <date>2023-03-18</date>
-    <minServerVersion>4.7.0</minServerVersion>
+    <date>2024-08-23</date>
+    <minServerVersion>4.8.1</minServerVersion>
 
     <adminconsole>
         <tab id="tab-groupchat">


### PR DESCRIPTION
Replaced Openfire API usage that was deprecated in Openfire 4.8.0 and removed in 4.9.0.

Plugin is now compatible with Openfire 4.9.0 and retains compatibility with 4.8.0. No longer compatible with versions older than 4.8.0.

fixes #23